### PR TITLE
Add missing Python 3.5 references (now supported)

### DIFF
--- a/etc/conda_build_matrix.py
+++ b/etc/conda_build_matrix.py
@@ -4,7 +4,7 @@ import subprocess
 
 import click
 
-py_versions = ('2.7', '3.4')
+py_versions = ('2.7', '3.4', '3.5')
 npy_versions = ('1.9', '1.10')
 zipline_path = os.path.join(
     os.path.dirname(__file__),

--- a/setup.py
+++ b/setup.py
@@ -305,6 +305,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Operating System :: OS Independent',
         'Intended Audience :: Science/Research',
         'Topic :: Office/Business :: Financial',


### PR DESCRIPTION
Add this version to the Conda build matrix and to the setup.py file.